### PR TITLE
Read credentials from the zypp directory first

### DIFF
--- a/credentials.go
+++ b/credentials.go
@@ -25,6 +25,7 @@ import (
 
 var credentialLocations = []string{
 	"/etc/zypp/credentials.d/SCCcredentials",
+	"/run/secrets/credentials.d/SCCcredentials",
 }
 
 type Credentials struct {


### PR DESCRIPTION
The SUSE connect service should read the SCC credentials stored inside
of /etc/zypp/credentials.d first and then, if not found, look for the
ones inside of /run/secrets/credentials.d
