### PR TITLE
Obtain SUSEConnect url by parsing SUSEConnect file

### DIFF
--- a/container-suseconnect.go
+++ b/container-suseconnect.go
@@ -17,15 +17,15 @@ package main
 
 import (
 	"log"
-	"os"
 	"net/url"
+	"os"
 )
 
 const (
 	sccUrlStr = "https://scc.suse.com"
 )
 
-func main () {
+func main() {
 
 	log.SetOutput(os.Stderr)
 
@@ -40,7 +40,10 @@ func main () {
 	}
 	log.Printf("Installed product: %v\n", installedProduct)
 
-	regUrlStr := os.Getenv("SCC_URL")
+	regUrlStr, err := ReadSUSEConnectUrl()
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
 	if regUrlStr == "" {
 		regUrlStr = sccUrlStr
 	}

--- a/suseconnect.go
+++ b/suseconnect.go
@@ -1,0 +1,85 @@
+//
+// Copyright (c) 2015 SUSE LLC. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+var suseConnectLocations = []string{
+	"/etc/SUSEConnect",
+	"/run/secrets/SUSEConnect",
+}
+
+func ParseSUSEConnect(reader io.Reader) (string, error) {
+	url := ""
+
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		// comments #
+		if strings.IndexAny(scanner.Text(), "#-") == 0 {
+			continue
+		}
+
+		// empty lines
+		if scanner.Text() == "" {
+			continue
+		}
+
+		parts := strings.SplitN(scanner.Text(), ":", 2)
+		if len(parts) != 2 {
+			return url, fmt.Errorf("Can't parse line: %v", scanner.Text())
+		}
+		if strings.Trim(parts[0], "\t ") == "url" {
+			url = strings.Trim(parts[1], "\t ")
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return url, err
+	}
+
+	return url, nil
+}
+
+func ReadSUSEConnectUrl() (string, error) {
+	var url string = ""
+	var suseConnectPath string = ""
+	for _, path := range suseConnectLocations {
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			continue
+		} else {
+			suseConnectPath = path
+			break
+		}
+	}
+
+	if suseConnectPath == "" {
+		return url, nil
+	}
+
+	file, err := os.Open(suseConnectPath)
+	if err != nil {
+		return url, fmt.Errorf("Can't open %s file: %v", suseConnectPath, err.Error())
+	}
+	defer file.Close()
+
+	return ParseSUSEConnect(file)
+}

--- a/suseconnect_test.go
+++ b/suseconnect_test.go
@@ -1,0 +1,82 @@
+//
+// Copyright (c) 2015 SUSE LLC. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+var suseConnect = `
+---
+## SUSEConnect configuration file example
+
+## URL of the registration server. (default: https://scc.suse.com)
+# url: https://scc.suse.com
+ url: 	https://smt.test.lan
+
+## Registration code to use for the base product on the system
+# regcode:
+
+## Language code to use for error messages (default: $LANG)
+# language:
+
+## Do not verify SSL certificates when using https (default: false)
+insecure: false
+`
+
+var suseConnectWithoutUrl = `
+---
+## SUSEConnect configuration file example
+
+## URL of the registration server. (default: https://scc.suse.com)
+# url: https://scc.suse.com
+
+## Registration code to use for the base product on the system
+# regcode:
+
+## Language code to use for error messages (default: $LANG)
+# language:
+
+## Do not verify SSL certificates when using https (default: false)
+insecure: false
+`
+
+func TestParseSUSEConnect(t *testing.T) {
+	reader := strings.NewReader(suseConnect)
+
+	url, err := ParseSUSEConnect(reader)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if url != "https://smt.test.lan" {
+		t.Fail()
+	}
+}
+
+func TestParseSUSEConnectWithoutUrl(t *testing.T) {
+	reader := strings.NewReader(suseConnectWithoutUrl)
+
+	url, err := ParseSUSEConnect(reader)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if url != "" {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
First attempt parsing /etc/SUSEConnect, then look for /run/secrets/SUSEConnect