### PR TITLE
Improve error message on non SLE hosts

### DIFF
--- a/internal/configuration.go
+++ b/internal/configuration.go
@@ -68,7 +68,7 @@ func ReadConfiguration(config Configuration) error {
 		if config.onLocationsNotFound() {
 			return nil
 		}
-		return loggedError("No locations found: %v", config.locations())
+		return loggedError("Warning: SUSE credentials not found: %v - automatic handling of repositories not done.", config.locations())
 	}
 
 	file, err := os.Open(path)

--- a/internal/configuration_test.go
+++ b/internal/configuration_test.go
@@ -63,10 +63,10 @@ func TestNotFound(t *testing.T) {
 
 	prepareLogger()
 	err := ReadConfiguration(&cfg)
-	if err == nil || err.Error() != "No locations found: []" {
+	if err == nil || err.Error() != "Warning: SUSE credentials not found: [] - automatic handling of repositories not done." {
 		t.Fatalf("Wrong error: %v", err)
 	}
-	shouldHaveLogged(t, "No locations found: []")
+	shouldHaveLogged(t, "Warning: SUSE credentials not found: [] - automatic handling of repositories not done.")
 }
 
 type NotAllowedConfiguration struct{}


### PR DESCRIPTION
Provide an explanation when the SMT/SCC credentials are not found inside of the container.

That probably means we are not running on a SLE host or the host itself is not registered against SMT/SCC.

We should not freak out the user, nothing wrong happens in this case: they just have to add repositories by hand.

Fixes bsc#1111216

The current output looks like the following one:

```
bash-4.3# zypper ref
Refreshing service 'container-suseconnect'.
Problem retrieving the repository index file for service 'container-suseconnect':
[container-suseconnect|file:/usr/lib/zypp/plugins/services/container-suseconnect] Cannot find SUSE credential files: no automatic handling of repositories, are you running this container on a registered SUSE Linux Enterprise host?
Warning: Skipping service 'container-suseconnect' because of the above error.
Warning: There are no enabled repositories defined.
Use 'zypper addrepo' or 'zypper modifyrepo' commands to add or enable repositories.
```
