### PR TITLE
Add documentation about how to build on non SLE distributions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GO_VERBOSE := -v
 CS_BUILD_DIR := $(PWD)/build/container-suseconnect
 
-export GO111MODULE=off
+export GO111MODULE=auto
 
 ifneq "$(VERBOSE)" "1"
 GO_VERBOSE=

--- a/internal/credentials.go
+++ b/internal/credentials.go
@@ -29,6 +29,7 @@ func (cr *Credentials) separator() byte {
 func (cr *Credentials) locations() []string {
 	return []string{
 		"/etc/zypp/credentials.d/SCCcredentials",
+		"/run/secrets/SCCcredentials",
 		"/run/secrets/credentials.d/SCCcredentials",
 	}
 }

--- a/internal/credentials_test.go
+++ b/internal/credentials_test.go
@@ -54,7 +54,10 @@ func TestCredentials(t *testing.T) {
 	if locs[0] != "/etc/zypp/credentials.d/SCCcredentials" {
 		t.Fatal("Wrong location")
 	}
-	if locs[1] != "/run/secrets/credentials.d/SCCcredentials" {
+	if locs[1] != "/run/secrets/SCCcredentials" {
+		t.Fatal("Wrong location")
+	}
+	if locs[2] != "/run/secrets/credentials.d/SCCcredentials" {
 		t.Fatal("Wrong location")
 	}
 


### PR DESCRIPTION
Please have a look at my proposed approach in how to build SLE docker images on other distributions than SLE. I think it is a bit experimental for now until the docker feature got stabilized, but I verified that it works functional and also in relation to security concerns.

What do you think?