### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/internal/configuration.go
+++ b/internal/configuration.go
@@ -59,7 +59,7 @@ func getLocationPath(locations []string) string {
 	return ""
 }
 
-// Reads the configuration and updates the given object.
+// ReadConfiguration reads the configuration and updates the given object.
 func ReadConfiguration(config Configuration) error {
 	path := getLocationPath(config.locations())
 	if path == "" {

--- a/internal/installed_product.go
+++ b/internal/installed_product.go
@@ -81,7 +81,7 @@ func readInstalledProduct(provider ProductProvider) (InstalledProduct, error) {
 	return parseInstalledProduct(xmlFile)
 }
 
-// Get the installed product on a SUSE machine.
+// GetInstalledProduct gets the installed product on a SUSE machine.
 func GetInstalledProduct() (InstalledProduct, error) {
 	var b SUSEProductProvider
 	return readInstalledProduct(b)

--- a/internal/logger.go
+++ b/internal/logger.go
@@ -28,7 +28,7 @@ var defaultLogPath = "/var/log/suseconnect.log"
 // path.
 const logEnv = "SUSECONNECT_LOG_FILE"
 
-// Returns the output file for the logger. If the `logEnv` environment
+// GetLoggerFile returns the output file for the logger. If the `logEnv` environment
 // variable has been set, it will try to output there. Otherwise, it
 // will try to output to the file as given in `defaultLogPath`. If
 // everything fails, it will just output to the standard error channel.

--- a/internal/service.go
+++ b/internal/service.go
@@ -105,7 +105,7 @@ func ListModules(w io.Writer, products []Product) {
 	}
 }
 
-// ListModules prints the provided `products` slice the provided writer `w` in a
+// ListProducts prints the provided `products` slice the provided writer `w` in a
 // human readable way
 func ListProducts(w io.Writer, products []Product, baseProduct string) {
 	for _, product := range products {


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?