### PR TITLE
Interacting with SCC behind proxy and SMT

### DIFF
--- a/internal/subscriptions.go
+++ b/internal/subscriptions.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/url"
 )
@@ -54,6 +55,15 @@ func requestRegcodes(data SUSEConnectData, credentials Credentials) ([]string, e
 	if err != nil {
 		return codes, err
 	}
+
+	if resp.StatusCode == 401 {
+		// we cannot requesting regcodes from s SMT server. It does not
+		// has this API. Just return a empty string
+		log.Println("Cannot fetch regcodes. Assuming it is SMT server")
+		codes = append(codes, "")
+		return codes, nil
+	}
+
 	if resp.StatusCode != 200 {
 		return codes,
 			loggedError("Unexpected error while retrieving regcode: %s", resp.Status)


### PR DESCRIPTION
When the user try to get the products from the SCC behind a proxy or
from a SMT server, container-suseconnect fails. This happens because it
checks if it need to get the regcodes just comparing the URL. Then, if
the user has a proxy, the URL will not be the expected one, skipping the
code to get the regcodes and by consequence, it cannot get the products
list.

Avoiding add more configuration option, this commit fixes this issue
always requesting the regcodes.  If the user uses a SMT server, which
does not have this API. The container-suseconnect assume it is a SMT
server and continue without the regcodes.

Issue #28
bsc#1127030

Signed-off-by: José Guilherme Vanz <jvanz@jvanz.com>