### PR TITLE
Interacting with SCC behind proxy and SMT

### DIFF
--- a/internal/products_test.go
+++ b/internal/products_test.go
@@ -119,10 +119,10 @@ func TestRemoteErrorWhileRequestingProducts(t *testing.T) {
 	// We setup a fake http server that mocks a registration server.
 	first_request := true
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// First request should return 401 to make the function request
+		// First request should return 404 to make the function request
 		// products and return 500 in the second request
 		if first_request {
-			http.Error(w, "something bad happened", 401)
+			http.Error(w, "something bad happened", 404)
 		} else {
 			http.Error(w, "something bad happened", 500)
 		}

--- a/internal/products_test.go
+++ b/internal/products_test.go
@@ -110,16 +110,23 @@ func TestFaultyRequestForProduct(t *testing.T) {
 	data := SUSEConnectData{SccURL: "http://", Insecure: true}
 
 	_, err := RequestProducts(data, cr, ip)
-	str := "Get http:///connect/subscriptions/products?arch=&identifier=&version=: http: no Host in request URL"
-	if err == nil || err.Error() != str {
+	if err == nil || !strings.HasSuffix(err.Error(), "no Host in request URL") {
 		t.Fatalf("There should be a proper error: %v", err)
 	}
 }
 
 func TestRemoteErrorWhileRequestingProducts(t *testing.T) {
 	// We setup a fake http server that mocks a registration server.
+	first_request := true
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "something bad happened", 500)
+		// First request should return 401 to make the function request
+		// products and return 500 in the second request
+		if first_request {
+			http.Error(w, "something bad happened", 401)
+		} else {
+			http.Error(w, "something bad happened", 500)
+		}
+		first_request = false
 	}))
 	defer ts.Close()
 

--- a/internal/subscriptions.go
+++ b/internal/subscriptions.go
@@ -56,7 +56,7 @@ func requestRegcodes(data SUSEConnectData, credentials Credentials) ([]string, e
 		return codes, err
 	}
 
-	if resp.StatusCode == 401 {
+	if resp.StatusCode == 404 {
 		// we cannot requesting regcodes from s SMT server. It does not
 		// has this API. Just return a empty string
 		log.Println("Cannot fetch regcodes. Assuming it is SMT server")

--- a/internal/subscriptions.go
+++ b/internal/subscriptions.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/url"
 )
@@ -54,6 +55,15 @@ func requestRegcodes(data SUSEConnectData, credentials Credentials) ([]string, e
 	if err != nil {
 		return codes, err
 	}
+
+	if resp.StatusCode == 401 {
+		// we cannot requesting regcodes from s SMT server. It does not
+		// has this API. Just return a empty string
+		log.Println("Cannot fetch regcodes. Assuming it is SMT server")
+		codes = append(codes, "")
+		return codes, nil
+	}
+
 	if resp.StatusCode != 200 {
 		return codes,
 			loggedError("Unexpected error while retrieving regcode: %s", resp.Status)


### PR DESCRIPTION
When the user try to get the products from the SCC behind a proxy or from a SMT server, container-suseconnect fails. This happens because it checks if it need to get the regcodes just comparing the URL. Then, if the user has a proxy, the URL will not be the expected one, skipping the code to get the regcodes and by consequence, it cannot get the products list.

 Avoiding add more configuration option, this commit fixes this issue always requesting the regcodes.  If the user uses a SMT server, which does not have this API. The container-suseconnect assume it is a SMT server and continue without the regcodes.