### PR TITLE
service.go: parse the /etc/products.d/*.prod files

### DIFF
--- a/internal/service.go
+++ b/internal/service.go
@@ -101,7 +101,8 @@ func moduleEnabledInProductFiles(identifier string) bool {
 	}
 	for _, file := range files {
 		ext := filepath.Ext(file.Name())
-		if identifier == strings.TrimSuffix(file.Name(), ext) &&
+		if ext == ".prod" &&
+			identifier == strings.TrimSuffix(file.Name(), ext) &&
 			file.Mode()&os.ModeSymlink == 0 {
 			return true
 		}

--- a/internal/service.go
+++ b/internal/service.go
@@ -17,6 +17,7 @@ package containersuseconnect
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -59,7 +60,8 @@ func dumpRepositoriesRecursive(
 ) {
 	for _, repo := range product.Repositories {
 		if product.Recommended || dumpAlways ||
-			moduleEnabledInEnv(product.Identifier) {
+			moduleEnabledInEnv(product.Identifier) ||
+			moduleEnabledInProductFiles(product.Identifier) {
 
 			fmt.Fprintf(w, "[%s]\n", repo.Name)
 			fmt.Fprintf(w, "name=%s\n", repo.Description)
@@ -83,6 +85,21 @@ func dumpRepositoriesRecursive(
 func moduleEnabledInEnv(identifier string) bool {
 	for _, i := range strings.Split(os.Getenv("ADDITIONAL_MODULES"), ",") {
 		if identifier == i {
+			return true
+		}
+	}
+	return false
+}
+
+// moduleEnabledInProductFiles returns true if the provided `identifier` is
+// a name of a file in the  /etc/product.d/*.prod, otherwise false.
+func moduleEnabledInProductFiles(identifier string) bool {
+	files, err := ioutil.ReadDir("/etc/products.d")
+	if err != nil {
+		return false
+	}
+	for _, file := range files {
+		if identifier == strings.TrimSuffix(file.Name(), ".prod") {
 			return true
 		}
 	}

--- a/internal/service.go
+++ b/internal/service.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -99,7 +100,9 @@ func moduleEnabledInProductFiles(identifier string) bool {
 		return false
 	}
 	for _, file := range files {
-		if identifier == strings.TrimSuffix(file.Name(), ".prod") {
+		ext := filepath.Ext(file.Name())
+		if identifier == strings.TrimSuffix(file.Name(), ext) &&
+			file.Mode()&os.ModeSymlink == 0 {
 			return true
 		}
 	}


### PR DESCRIPTION
Adds a code in the service.go to parse the *.prod files. This allow the
user not use the ADDITIONAL_MODULES and parses the file under
/etc/products.d folder. The function uses the file name in  the same
way as  identifier specified in the ADDITIONAL_MODULES environment
variable. Issue #27

Signed-off-by: José Guilherme Vanz <jguilhermevanz@suse.com>