### PR TITLE
Rework ReadConfigFromServer() to use json.Decoder

### DIFF
--- a/internal/regionsrv/server.go
+++ b/internal/regionsrv/server.go
@@ -89,17 +89,10 @@ func ReadConfigFromServer() (*ContainerBuildConfig, error) {
 	defer conn.Close()
 	log.Printf("Reading from containerbuild-regionsrv ...")
 
-	// After testing it turns out that we need something a bit over 2048, but
-	// let's leave some extra room just in case...
-	reply := make([]byte, 8192)
-
-	n, err := conn.Read(reply)
-	if err != nil {
-		return nil, err
-	}
+	d := json.NewDecoder(conn)
 
 	data := &ContainerBuildConfig{}
-	if err := json.Unmarshal(reply[:n], &data); err != nil {
+	if err := d.Decode(&data); err != nil {
 		return nil, err
 	}
 

--- a/internal/regionsrv/server_test.go
+++ b/internal/regionsrv/server_test.go
@@ -109,8 +109,8 @@ func TestReadConfigFromServerBadResponse(t *testing.T) {
 		<-ts.bootstrapped
 
 		_, err := ReadConfigFromServer()
-		if !strings.Contains(err.Error(), "unexpected end of JSON input") {
-			t.Fatalf("should be a 'unexpected end of JSON input', got '%v'", err)
+		if !strings.Contains(err.Error(), "invalid character '{' looking for beginning of object key string") {
+			t.Fatalf("should be a 'invalid character '{' looking for beginning of object key string', got '%v'", err)
 		}
 	})
 }


### PR DESCRIPTION
Using Read() directly has the risk of doing a short read. E.g. on a busy
machine it might not read an entire JSON Object in one call. Switch the
implementation to use json.Decoder and rely on it doing the Right Thing (TM)

Adjust the Test Case accordingly to check for the correct error message.