### PR TITLE
Add flag --log-credentials-errors

### DIFF
--- a/internal/configuration.go
+++ b/internal/configuration.go
@@ -68,12 +68,12 @@ func ReadConfiguration(config Configuration) error {
 		if config.onLocationsNotFound() {
 			return nil
 		}
-		return loggedError("Warning: SUSE credentials not found: %v - automatic handling of repositories not done.", config.locations())
+		return loggedError(GetCredentialsError, "Warning: SUSE credentials not found: %v - automatic handling of repositories not done.", config.locations())
 	}
 
 	file, err := os.Open(path)
 	if err != nil {
-		return loggedError("Can't open %s file: %v", path, err.Error())
+		return loggedError(GetCredentialsError, "Can't open %s file: %v", path, err.Error())
 	}
 	defer file.Close()
 
@@ -96,7 +96,7 @@ func parse(config Configuration, reader io.Reader) error {
 		line := scanner.Text()
 		parts := strings.SplitN(line, string(config.separator()), 2)
 		if len(parts) != 2 {
-			return loggedError("Can't parse line: %v", line)
+			return loggedError(GetCredentialsError, "Can't parse line: %v", line)
 		}
 
 		// And finally trim the key and the value and pass it to the config.
@@ -106,7 +106,7 @@ func parse(config Configuration, reader io.Reader) error {
 
 	// Final checks.
 	if err := scanner.Err(); err != nil {
-		return loggedError("Error when scanning configuration: %v", err)
+		return loggedError(GetCredentialsError, "Error when scanning configuration: %v", err)
 	}
 	if err := config.afterParseCheck(); err != nil {
 		return err

--- a/internal/credentials.go
+++ b/internal/credentials.go
@@ -54,10 +54,10 @@ func (cr *Credentials) setValues(key, value string) {
 
 func (cr *Credentials) afterParseCheck() error {
 	if cr.Username == "" {
-		return loggedError("Can't find username")
+		return loggedError(GetCredentialsError, "Can't find username")
 	}
 	if cr.Password == "" {
-		return loggedError("Can't find password")
+		return loggedError(GetCredentialsError, "Can't find password")
 	}
 	return nil
 }

--- a/internal/error.go
+++ b/internal/error.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2022 SUSE LLC. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package containersuseconnect
+
+const (
+	// GetCredentialsError indicates a failure to retrieve or parse
+	// credentials
+	GetCredentialsError = iota
+	// NetworkError is a placeholder for generic network communication
+	// errors
+	NetworkError
+	// InstalledProductError signals issues with the installed products
+	InstalledProductError
+	// SubscriptionServerError means that the subscription server did
+	// something unexpected
+	SubscriptionServerError
+	// SubscriptionError marks issues with the actual subscription
+	SubscriptionError
+	// RepositoryError indicates that there is something wrong with the
+	// repository that the subscription server gave us
+	RepositoryError
+)
+
+// SuseConnectError is a custom error type allowing us to distinguish between
+// different error kinds via the `ErrorCode` field
+type SuseConnectError struct {
+	ErrorCode int
+	message   string
+}
+
+func (s *SuseConnectError) Error() string {
+	return s.message
+}

--- a/internal/installed_product.go
+++ b/internal/installed_product.go
@@ -62,7 +62,7 @@ func parseInstalledProduct(reader io.Reader) (InstalledProduct, error) {
 	err := xml.Unmarshal(xmlData, &p)
 	if err != nil {
 		return InstalledProduct{},
-			loggedError("Can't parse base product file: %v", err.Error())
+			loggedError(InstalledProductError, "Can't parse base product file: %v", err.Error())
 	}
 	return p, nil
 }
@@ -70,13 +70,13 @@ func parseInstalledProduct(reader io.Reader) (InstalledProduct, error) {
 // Read the product file from the standard location
 func readInstalledProduct(provider ProductProvider) (InstalledProduct, error) {
 	if _, err := os.Stat(provider.Location()); os.IsNotExist(err) {
-		return InstalledProduct{}, loggedError("No base product detected")
+		return InstalledProduct{}, loggedError(InstalledProductError, "No base product detected")
 	}
 
 	xmlFile, err := os.Open(provider.Location())
 	if err != nil {
 		return InstalledProduct{},
-			loggedError("Can't open base product file: %v", err.Error())
+			loggedError(InstalledProductError, "Can't open base product file: %v", err.Error())
 	}
 	defer xmlFile.Close()
 

--- a/internal/logger.go
+++ b/internal/logger.go
@@ -15,7 +15,6 @@
 package containersuseconnect
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -51,8 +50,11 @@ func GetLoggerFile() *os.File {
 
 // Log the given formatted string with its parameters, and return it
 // as a new error.
-func loggedError(format string, params ...interface{}) error {
-	str := fmt.Sprintf(format, params...)
-	log.Print(str)
-	return errors.New(str)
+func loggedError(errorCode int, format string, params ...interface{}) *SuseConnectError {
+	msg := fmt.Sprintf(format, params...)
+	log.Print(msg)
+	return &SuseConnectError{
+		ErrorCode: errorCode,
+		message:   msg,
+	}
 }

--- a/internal/products.go
+++ b/internal/products.go
@@ -56,7 +56,7 @@ func fixRepoUrlsForRMT(p *Product) error {
 	for i := range p.Repositories {
 		repourl, err := url.Parse(p.Repositories[i].URL)
 		if err != nil {
-			loggedError("Unable to parse repository URL: %s - %v", p.Repositories[i].URL, err)
+			loggedError(RepositoryError, "Unable to parse repository URL: %s - %v", p.Repositories[i].URL, err)
 			return err
 		}
 		params := repourl.Query()
@@ -84,7 +84,7 @@ func parseProducts(reader io.Reader) ([]Product, error) {
 	data, err := ioutil.ReadAll(reader)
 	if err != nil {
 		return products,
-			loggedError("Can't read product information: %v", err.Error())
+			loggedError(RepositoryError, "Can't read product information: %v", err.Error())
 	}
 
 	// Depending on which API was used the JSON we get passed contains
@@ -107,7 +107,7 @@ func parseProducts(reader io.Reader) ([]Product, error) {
 	}
 	if err != nil {
 		return products,
-			loggedError("Can't read product information: %v - %s", err.Error(), data)
+			loggedError(RepositoryError, "Can't read product information: %v - %s", err.Error(), data)
 	}
 	return products, nil
 }
@@ -130,7 +130,7 @@ func requestProductsFromRegCodeOrSystem(data SUSEConnectData, regCode string,
 	req, err := http.NewRequest("GET", data.SccURL, nil)
 	if err != nil {
 		return products,
-			loggedError("Could not connect with registration server: %v\n", err)
+			loggedError(NetworkError, "Could not connect with registration server: %v\n", err)
 	}
 
 	values := req.URL.Query()
@@ -162,7 +162,7 @@ func requestProductsFromRegCodeOrSystem(data SUSEConnectData, regCode string,
 			}
 		}
 		return products,
-			loggedError("Unexpected error while retrieving products with regCode %s: %s", regCode, resp.Status)
+			loggedError(SubscriptionServerError, "Unexpected error while retrieving products with regCode %s: %s", regCode, resp.Status)
 	}
 
 	return parseProducts(resp.Body)

--- a/internal/subscriptions.go
+++ b/internal/subscriptions.go
@@ -44,7 +44,7 @@ func requestRegcodes(data SUSEConnectData, credentials Credentials) ([]string, e
 	req, err := http.NewRequest("GET", data.SccURL, nil)
 	if err != nil {
 		return codes,
-			loggedError("Could not connect with registration server: %v\n", err)
+			loggedError(NetworkError, "Could not connect with registration server: %v\n", err)
 	}
 
 	req.URL.Path = "/connect/systems/subscriptions"
@@ -67,7 +67,7 @@ func requestRegcodes(data SUSEConnectData, credentials Credentials) ([]string, e
 
 	if resp.StatusCode != 200 {
 		return codes,
-			loggedError("Unexpected error while retrieving regcode: %s", resp.Status)
+			loggedError(SubscriptionServerError, "Unexpected error while retrieving regcode: %s", resp.Status)
 	}
 
 	subscriptions, err := parseSubscriptions(resp.Body)
@@ -88,15 +88,15 @@ func parseSubscriptions(reader io.Reader) ([]Subscription, error) {
 
 	data, err := ioutil.ReadAll(reader)
 	if err != nil {
-		return subscriptions, loggedError("Can't read subscriptions information: %v", err.Error())
+		return subscriptions, loggedError(SubscriptionError, "Can't read subscriptions information: %v", err.Error())
 	}
 
 	err = json.Unmarshal(data, &subscriptions)
 	if err != nil {
-		return subscriptions, loggedError("Can't read subscription: %v", err.Error())
+		return subscriptions, loggedError(SubscriptionError, "Can't read subscription: %v", err.Error())
 	}
 	if len(subscriptions) == 0 {
-		return subscriptions, loggedError("Got 0 subscriptions")
+		return subscriptions, loggedError(SubscriptionError, "Got 0 subscriptions")
 	}
 	return subscriptions, nil
 }


### PR DESCRIPTION
Currently container-suseconnect will print errors to the console when it fails
to obtain the SLE credentials. This is however causing UX issues in the SLE BCI
containers, which work perfectly fine without a SLE subscription.

Thus a new flag is introduced: `--log-credentials-errors`. When this flag is set
or if the environment variable `CONTAINER_SUSECONNECT_LOG_CREDENTIALS_ERR` is
set, then `container-suseconnect` will continue printing errors as it did, but
the default is now that errors with obtaining the credentials will be silently
swallowed so that users of SLE BCI don't get confused by this error message.

This fixes https://github.com/SUSE/container-suseconnect/issues/62