### PR TITLE
Regcode fix

### DIFF
--- a/internal/products.go
+++ b/internal/products.go
@@ -184,13 +184,17 @@ func RequestProducts(data SUSEConnectData, credentials Credentials,
 	}
 
 	for _, regCode := range regCodes {
-		p, err := requestProductsFromRegCodeOrSystem(data, regCode, credentials, installed)
-		if err != nil {
-			var emptyProducts []Product
-			return emptyProducts, err
+		p, _err := requestProductsFromRegCodeOrSystem(data, regCode, credentials, installed)
+		if _err != nil {
+			err = _err
+			continue
 		}
 		products = append(products, p...)
 	}
 
-	return products, nil
+	if len(products) > 0 {
+		err = nil
+	}
+
+	return products, err
 }

--- a/internal/subscriptions.go
+++ b/internal/subscriptions.go
@@ -81,7 +81,7 @@ func requestRegcodes(data SUSEConnectData, credentials Credentials) ([]string, e
 		if strings.ToUpper(subscription.Status) != "EXPIRED" {
 			codes = append(codes, subscription.RegCode)
 		} else {
-			log.Printf("Skipping regCode: %s -- expired.", subscription.RegCode)
+			loggedError(SubscriptionServerError, "Skipping regCode: %s -- expired.", subscription.RegCode)
 		}
 	}
 	return codes, err

--- a/internal/subscriptions.go
+++ b/internal/subscriptions.go
@@ -22,11 +22,13 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 // Subscription has all the information that we need for SLE subscriptions.
 type Subscription struct {
 	RegCode string `json:"regcode"`
+	Status  string `json:"status"`
 }
 
 // Request registration codes to the registration server. The `data` and the
@@ -76,7 +78,11 @@ func requestRegcodes(data SUSEConnectData, credentials Credentials) ([]string, e
 	}
 
 	for _, subscription := range subscriptions {
-		codes = append(codes, subscription.RegCode)
+		if strings.ToUpper(subscription.Status) != "EXPIRED" {
+			codes = append(codes, subscription.RegCode)
+		} else {
+			log.Printf("Skipping regCode: %s -- expired.", subscription.RegCode)
+		}
 	}
 	return codes, err
 }

--- a/internal/subscriptions_test.go
+++ b/internal/subscriptions_test.go
@@ -83,7 +83,7 @@ func TestValidSubscriptions(t *testing.T) {
 	if err != nil {
 		t.Fatal("Unexpected error when reading a valid JSON file")
 	}
-	if len(subscriptions) != 1 {
+	if len(subscriptions) != 2 {
 		t.Fatalf("Unexpected number of subscriptions found. Got %d, expected %d", len(subscriptions), 1)
 	}
 	subscriptionHelper(t, subscriptions[0])
@@ -147,6 +147,7 @@ func TestValidRequestForRegcodes(t *testing.T) {
 	if err != nil {
 		t.Fatal("It should've run just fine...")
 	}
+	// This also tests that we're not including expired regcodes
 	if len(codes) != 1 {
 		t.Fatalf("Unexpected number of products found. Got %d, expected %d", len(codes), 1)
 	}

--- a/internal/testdata/subscriptions.json
+++ b/internal/testdata/subscriptions.json
@@ -14,5 +14,21 @@
     "families": ["sles", "sled"],
     "systems": [{ "id": 117, "login": "login2", "password": "password2" }],
     "product_ids": [239, 238, 240]
+  },
+  {
+    "id": 113,
+    "regcode": "35098ff7-expired",
+    "name": "Subscription 3",
+    "type": null,
+    "status": "EXPIRED",
+    "starts_at": "2010-05-14T09:13:26.589Z",
+    "expires_at": "2014-05-14T09:13:26.589Z",
+    "system_limit": 1,
+    "systems_count": 1,
+    "virtual_count": null,
+    "product_classes": ["7260"],
+    "families": ["sles", "sled"],
+    "systems": [{ "id": 117, "login": "login2", "password": "password2" }],
+    "product_ids": [239, 238, 240]
   }
 ]


### PR DESCRIPTION
Fix for expired / not working regcode. See Issue #58.

In addition to not returning expired subscriptions, RequestProducts() doesn't return an error if at least one regcode worked and returned at least one product.