### PR TITLE
Add system token header to query SCC subscriptions (bsc#1219855)

### DIFF
--- a/internal/products.go
+++ b/internal/products.go
@@ -146,6 +146,9 @@ func requestProductsFromRegCodeOrSystem(data SUSEConnectData, regCode string,
 		req.URL.Path = "/connect/systems/products"
 		auth := url.UserPassword(credentials.Username, credentials.Password)
 		req.URL.User = auth
+		if credentials.SystemToken != "" {
+			req.Header.Add("System-Token", credentials.SystemToken)
+		}
 	}
 
 	resp, err := client.Do(req)

--- a/internal/subscriptions.go
+++ b/internal/subscriptions.go
@@ -51,6 +51,9 @@ func requestRegcodes(data SUSEConnectData, credentials Credentials) ([]string, e
 	req.URL.Path = "/connect/systems/subscriptions"
 
 	auth := url.UserPassword(credentials.Username, credentials.Password)
+	if credentials.SystemToken != "" {
+		req.Header.Add("System-Token", credentials.SystemToken)
+	}
 	req.URL.User = auth
 
 	resp, err := client.Do(req)


### PR DESCRIPTION
when a system was cloned, SCC falls back to the first system ever registered for determining subscriptions. passing in the system token should help with that.
