### PR TITLE
Do not log credentials errors

### DIFF
--- a/internal/configuration.go
+++ b/internal/configuration.go
@@ -70,12 +70,12 @@ func ReadConfiguration(config Configuration) error {
 			return nil
 		}
 
-		return loggedError(GetCredentialsError, "Warning: SUSE credentials not found: %v - automatic handling of repositories not done.", config.locations())
+		return loggedError(CredentialsNotFoundError, "SUSE Credentials not found at %v. Skipping automatic handling of repositories.", config.locations())
 	}
 
 	file, err := os.Open(path)
 	if err != nil {
-		return loggedError(GetCredentialsError, "Can't open %s file: %v", path, err.Error())
+		return loggedError(CredentialsNotFoundError, "Can't open %s file: %v", path, err.Error())
 	}
 	defer file.Close()
 
@@ -101,7 +101,7 @@ func parse(config Configuration, reader io.Reader) error {
 		parts := strings.SplitN(line, string(config.separator()), 2)
 
 		if len(parts) != 2 {
-			return loggedError(GetCredentialsError, "Can't parse line: %v", line)
+			return loggedError(InvalidCredentialsError, "Can't parse line: %v", line)
 		}
 
 		// And finally trim the key and the value and pass it to the config.
@@ -111,7 +111,7 @@ func parse(config Configuration, reader io.Reader) error {
 
 	// Final checks.
 	if err := scanner.Err(); err != nil {
-		return loggedError(GetCredentialsError, "Error when scanning configuration: %v", err)
+		return loggedError(InvalidCredentialsError, "Error when scanning configuration: %v", err)
 	}
 
 	if err := config.afterParseCheck(); err != nil {

--- a/internal/configuration_test.go
+++ b/internal/configuration_test.go
@@ -65,11 +65,11 @@ func TestNotFound(t *testing.T) {
 	prepareLogger()
 
 	err := ReadConfiguration(&cfg)
-	if err == nil || err.Error() != "Warning: SUSE credentials not found: [] - automatic handling of repositories not done." {
+	if err == nil || err.Error() != "SUSE Credentials not found at []. Skipping automatic handling of repositories." {
 		t.Fatalf("Wrong error: %v", err)
 	}
 
-	shouldHaveLogged(t, "Warning: SUSE credentials not found: [] - automatic handling of repositories not done.")
+	shouldHaveLogged(t, "SUSE Credentials not found at []. Skipping automatic handling of repositories.")
 }
 
 type NotAllowedConfiguration struct{}

--- a/internal/credentials.go
+++ b/internal/credentials.go
@@ -72,11 +72,11 @@ func (cr *Credentials) setValues(key, value string) {
 
 func (cr *Credentials) afterParseCheck() error {
 	if cr.Username == "" {
-		return loggedError(GetCredentialsError, "Can't find username")
+		return loggedError(InvalidCredentialsError, "Can't find username")
 	}
 
 	if cr.Password == "" {
-		return loggedError(GetCredentialsError, "Can't find password")
+		return loggedError(InvalidCredentialsError, "Can't find password")
 	}
 
 	return nil

--- a/internal/error.go
+++ b/internal/error.go
@@ -14,10 +14,13 @@
 
 package containersuseconnect
 
+import "errors"
+
 const (
-	// GetCredentialsError indicates a failure to retrieve or parse
-	// credentials
-	GetCredentialsError = iota
+	// CredentialsNotFoundError means missing credentials
+	CredentialsNotFoundError = iota
+	// InvalidCredentialsError indicates an error parsing credentials
+	InvalidCredentialsError
 	// NetworkError is a placeholder for generic network communication
 	// errors
 	NetworkError
@@ -42,4 +45,14 @@ type SuseConnectError struct {
 
 func (s *SuseConnectError) Error() string {
 	return s.message
+}
+
+func IsCredentialsNotFoundError(err error) bool {
+	var scerr *SuseConnectError
+
+	if errors.As(err, &scerr) {
+		return scerr.ErrorCode == CredentialsNotFoundError
+	}
+
+	return false
 }

--- a/internal/error_test.go
+++ b/internal/error_test.go
@@ -1,0 +1,23 @@
+package containersuseconnect
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsCredentialsNotFoundError(t *testing.T) {
+	err := &SuseConnectError{
+		ErrorCode: CredentialsNotFoundError,
+	}
+
+	assert.True(t, IsCredentialsNotFoundError(err))
+}
+
+func TestIsNotCredentialsNotFoundError(t *testing.T) {
+	err := &SuseConnectError{
+		ErrorCode: InvalidCredentialsError,
+	}
+
+	assert.False(t, IsCredentialsNotFoundError(err))
+}


### PR DESCRIPTION
This reverts #93 partially because it causes zyppers to log errors every time it fails to locate credentials files.

Failures are still logged to a file, but not propagated to zypper.