### PR TITLE
Change the version logic

### DIFF
--- a/cmd/container-suseconnect/main.go
+++ b/cmd/container-suseconnect/main.go
@@ -40,7 +40,7 @@ func init() {
 	}
 
 	flag.BoolFunc("version", "print version and exit", func(string) error {
-		fmt.Println(cs.Version)
+		fmt.Println(cs.GetVersion())
 		os.Exit(0)
 		return nil
 	})

--- a/internal/logger.go
+++ b/internal/logger.go
@@ -59,7 +59,7 @@ func getLogWritter(path string) (io.WriteCloser, error) {
 		}
 	}
 
-	_, err = fmt.Fprintf(lf, "container-suseconnect %s\n", Version)
+	_, err = fmt.Fprintf(lf, "container-suseconnect %s\n", GetVersion())
 	if err != nil {
 		lf.Close()
 		return nil, err

--- a/internal/version.go
+++ b/internal/version.go
@@ -14,5 +14,58 @@
 
 package containersuseconnect
 
-// Version holds the current version of the application.
-const Version = "2.5.2"
+import (
+	"fmt"
+	"runtime/debug"
+	"strconv"
+)
+
+var (
+	version  string
+	revision string
+)
+
+// GetVersion returns the version and revision if available.
+// If both version and revision are found, it returns "%version (%revision)".
+// If only version is found, it returns "%version".
+// If no version is found but a revision is, it returns "devel (%revision)".
+// If no version and no revision are found, it returns "devel".
+// The revision can taken from the binary if it was stamped with version
+// control information.
+func GetVersion() string {
+	if version == "" {
+		version = "devel"
+	}
+
+	if revision == "" {
+		bi, ok := debug.ReadBuildInfo()
+
+		if !ok {
+			return version
+		}
+
+		var vcsRevision string
+		var vcsModified bool
+
+		for _, s := range bi.Settings {
+			switch s.Key {
+			case "vcs.revision":
+				vcsRevision = s.Value
+			case "vcs.modified":
+				vcsModified, _ = strconv.ParseBool(s.Value)
+			}
+		}
+
+		if vcsRevision == "" {
+			return version
+		} else {
+			revision = vcsRevision[:7]
+
+			if vcsModified {
+				revision = revision + "+modified"
+			}
+		}
+	}
+
+	return fmt.Sprintf("%s (%s)", version, revision)
+}

--- a/internal/version_test.go
+++ b/internal/version_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2025 SUSE LLC. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package containersuseconnect
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetVersionWithVersionRevisionUnset(t *testing.T) {
+	version = ""
+	revision = ""
+
+	assert.Equal(t, "devel", GetVersion())
+}
+
+func TestGetVersionWithVersionSet(t *testing.T) {
+	version = "1.2.3"
+	revision = ""
+
+	assert.Equal(t, "1.2.3", GetVersion())
+}
+
+func TestGetVersionWithRevisionSet(t *testing.T) {
+	version = ""
+	revision = "gh12345"
+
+	assert.Equal(t, "devel (gh12345)", GetVersion())
+}
+
+func TestGetVersionWithVersionRevisionSet(t *testing.T) {
+	version = "1.2.3"
+	revision = "gh12345"
+
+	assert.Equal(t, "1.2.3 (gh12345)", GetVersion())
+}


### PR DESCRIPTION
Allow to override the version during build time.
Allow to also set a Git revision during build time.
Extract VCS information from the binary if needed and available.